### PR TITLE
Fix typos

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WP Knowledgebase ===
-Contributors: EnigmaWeb, helgatheviking, Base29
+Contributors: EnigmaWeb, helgatheviking, Base29, macbookandrew
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=CEJ9HFWJ94BG4
 Tags: WP Knowledgebase, knowledgebase, knowledge base, faqs, wiki
 Requires at least: 2.7

--- a/wp-knowledgebase.php
+++ b/wp-knowledgebase.php
@@ -30,11 +30,11 @@ function kbe_register_settings() {
 }
 
 /**
-+ * Sanitize and validate plugin settings
-+ * @param  array $input
-+ * @return array
-+ * @since  1.1.0
-+ */
+ * Sanitize and validate plugin settings
+ * @param  array $input
+ * @return array
+ * @since  1.1.0
+ */
 function kbe_validate_settings( $input ) {
     $input['kbe_plugin_slug'] = isset( $input['kbe_plugin_slug'] ) ? sanitize_title( $input['kbe_plugin_slug'] ) : '';
     $input['kbe_article_qty'] = intval( $input['kbe_article_qty'] );


### PR DESCRIPTION
Fixes a couple of code comment typos that appear to be left over from copying/pasting a git message.

Also added myself as a contributor due to the other changes from last week; feel free to reject if you don’t want me listed.

Thanks!