### PR TITLE
Fix two notices

### DIFF
--- a/kbe_order.php
+++ b/kbe_order.php
@@ -48,7 +48,7 @@
                             <?php
                                 foreach($kbe_terms as $kbe_term) :
                             ?>
-                                    <li id="kbe_parent_id_<?php echo $kbe_term->term_id; ?>" class="lineitem <?php echo ($i % 2 == 0 ? 'alternate ' : ''); ?>ui-state-default">
+                                    <li id="kbe_parent_id_<?php echo $kbe_term->term_id; ?>" class="lineitem ui-state-default">
                                         <?php echo $kbe_term->name; ?>
                                     </li>
                             <?php

--- a/wp-knowledgebase.php
+++ b/wp-knowledgebase.php
@@ -226,9 +226,8 @@ $kbe_settings = get_option('kbe_settings');
 if (isset($kbe_settings['kbe_article_qty'])){
     define('KBE_ARTICLE_QTY', $kbe_settings['kbe_article_qty']);
 }
-if (isset($kbe_settings['kbe_plugin_slug'])){
-    define('KBE_PLUGIN_SLUG', $kbe_settings['kbe_plugin_slug']);
-}
+define('KBE_PLUGIN_SLUG', isset( $kbe_settings['kbe_plugin_slug'] ) ? $kbe_settings['kbe_plugin_slug'] : 'knowledgebase');
+
 if (isset($kbe_settings['kbe_search_setting'])){
     define('KBE_SEARCH_SETTING', $kbe_settings['kbe_search_setting']);
 }


### PR DESCRIPTION
- Fix notices on 'order' page, ' not defined', removeing 'alternate' class, style overridden anyway
- Fix Notice when activating the plugin,, KBE_PLUGIN_SLUG not defined 