### PR TITLE
Clean up the uninstall.php file

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -12,8 +12,6 @@ if ( ! isset( $options['kbe_wipe_uninstall'] ) || false == $options['kbe_wipe_un
 
 global $wpdb;
 
-$kbe_tbl_prefix = $wpdb->prefix;
-
 //=========> Delete Plugin Settings From options Table
 delete_option( 'kbe_settings' );
 delete_option( 'kbe_bgcolor' );
@@ -30,102 +28,35 @@ delete_option( 'widget_kbe_search_widget' );
 delete_option( 'widget_kbe_article_widget' );
 delete_option( 'widget_kbe_category_widget' );
 
-//=========> Delete `terms_order` Column From trms Table
-$wpdb->query( 'ALTER TABLE ' . $kbe_tbl_prefix . 'terms DROP COLUMN `terms_order`' );
+// Delete `terms_order` Column From terms Table
+$wpdb->query( "ALTER TABLE {$wpdb->terms} DROP COLUMN `terms_order`" );
 
-//=========> Get Knowledgebase page and Delete all relivent Data
-$kbe_get_page = $wpdb->get_results( 'Select * From ' . $wpdb->prefix . "posts
-									Where post_content like '%[kbe_knowledgebase]%'
-									and post_type = 'page'" );
-
-foreach ( $kbe_get_page as $get_page ) {
-	$kbe_page_ID = $get_page->ID;
-
-	//Delete all Knowledgebase page Relivent data from `postmeta` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "postmeta Where post_id = $kbe_page_ID" );
-
-	//Delete all Knowledgebase page Child data from `posts` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "posts Where post_parent = $kbe_page_ID" );
-
-	//Delete Knowledgebase page from `posts` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "posts Where ID = $kbe_page_ID" );
+// Delete Knowledgebase page
+if ( $post_id = kbe_get_knowledgebase_page_id() ) {
+	wp_delete_post( $post_id, true );
 }
 
-//=========> Get all Images of `kbe_knowledgebase` post type and Delete all Images Data
-$kbe_get_post_images = $wpdb->get_results( 'Select * From ' . $wpdb->prefix . "posts Where post_type = 'kbe_knowledgebase'" );
-
-$kbe_upload_dir = wp_upload_dir();
-
-foreach ( $kbe_get_post_images as $get_post_images ) {
-	$kbe_posts_img_ID = $get_post_images->ID;
-
-	$kbe_post_imgs_qry = $wpdb->get_results( 'Select * From ' . $wpdb->prefix . "posts
-											Where post_parent = $kbe_posts_img_ID
-											And post_type = 'attachment'
-											And post_mime_type = 'image/jpeg'" );
-	foreach ( $kbe_post_imgs_qry as $get_post_img ) {
-		$kbe_img_ID = $get_post_img->ID;
-
-		// Extract path from images
-		$kbe_img_path      = get_post_meta( $kbe_img_ID, '_wp_attached_file', true );
-		$kbe_main_img_name = substr( $kbe_img_path, strrpos( $kbe_img_path, '/' )+1 );
-		$kbe_sub_path      = substr( $kbe_img_path, 0, strrpos( $kbe_img_path, '/' ) );
-
-		$kbe_img_meta = get_post_meta( $kbe_img_ID, '_wp_attachment_metadata', true );
-
-		$kbe_thumbnail      = $kbe_img_meta['sizes']['thumbnail']['file'];
-		$kbe_medium         = $kbe_img_meta['sizes']['medium']['file'];
-		$kbe_post_thumbnail = $kbe_img_meta['sizes']['post-thumbnail']['file'];
-
-		$kbe_upload_path = $kbe_upload_dir['basedir'];
-
-		unlink( $kbe_upload_path . '/' . $kbe_sub_path . '/' . $kbe_main_img_name );
-		unlink( $kbe_upload_path . '/' . $kbe_sub_path . '/' . $kbe_thumbnail );
-		unlink( $kbe_upload_path . '/' . $kbe_sub_path . '/' . $kbe_medium );
-		unlink( $kbe_upload_path . '/' . $kbe_sub_path . '/' . $kbe_post_thumbnail );
-
-		//Delete all Knowledgebase Posts from `posts` Table
-		$wpdb->query( 'Delete From ' . $wpdb->prefix . "postmeta Where post_id = $kbe_img_ID" );
-	}
-}
-
-//=========> Get all Posts of `kbe_knowledgebase` post type and Delete all relevant Data
-$kbe_get_posts = $wpdb->get_results( 'Select * From ' . $wpdb->prefix . "posts Where post_type = 'kbe_knowledgebase'" );
-
-foreach ( $kbe_get_posts as $get_posts ) {
-	$kbe_posts_ID = $get_posts->ID;
-
-	//Delete all Comments of `kbe_knowledgebase` posts from `comments` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "comments Where comment_post_ID = $kbe_posts_ID" );
-
-	//Delete all Meta Data of `kbe_knowledgebase` posts from `postmeta` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "postmeta Where post_id = $kbe_posts_ID" );
-
-	//Delete all `kbe_knowledgebase` posts Realtion Data from `term_relationships` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "term_relationships Where object_id = $kbe_posts_ID" );
-
-	//Delete all `kbe_knowledgebase` Child data from `posts` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "posts Where post_parent = $kbe_posts_ID" );
-
-	//Delete all Knowledgebase Posts from `posts` Table
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "posts Where ID = $kbe_posts_ID" );
+// Delete the articles
+$kbe_get_posts = $wpdb->get_results( "SELECT ID From {$wpdb->posts} WHERE post_type = 'kbe_knowledgebase' LIMIT 500" );
+foreach ( $kbe_get_posts as $post ) {
+	wp_delete_post( $post->ID, true );
 }
 
 //=========> Delete All Categories and Tags of Knowledgebase
-$kbe_get_terms = $wpdb->get_results( 'Select kbe_term.*, kbe_tax.*
-									From ' . $wpdb->prefix . 'terms As kbe_term
-									Inner join ' . $wpdb->prefix . "term_taxonomy As kbe_tax
-									On kbe_term.term_id = kbe_tax.term_id
-									Where kbe_tax.taxonomy = 'kbe_taxonomy'
-									Or kbe_tax.taxonomy = 'kbe_tags'" );
+$kbe_get_terms = $wpdb->get_results(
+	"SELECT kbe_term.term_id, kbe_tax.term_id
+	From {$wpdb->terms} As kbe_term
+	Inner join {$wpdb->term_taxonomy} As kbe_tax
+	On kbe_term.term_id = kbe_tax.term_id
+	WHERE kbe_tax.taxonomy = 'kbe_taxonomy'
+	OR kbe_tax.taxonomy = 'kbe_tags'"
+);
 
-foreach ( $kbe_get_terms as $get_term ) {
-	$kbe_term_ID = $get_term->term_id;
-
-	$wpdb->query( 'Delete From ' . $wpdb->prefix . "terms Where term_id = $kbe_term_ID" );
+foreach ( $kbe_get_terms as $term ) {
+	$wpdb->query( "DELETE FROM {$wpdb->terms} WHERE term_id = $term->term_id" );
 }
 
 //=========> Delete All Taxonomies and Tags of Knowledgebase
-$wpdb->query( 'Delete From ' . $wpdb->prefix . "term_taxonomy Where taxonomy = 'kbe_taxonomy'" );
+$wpdb->query( "DELETE FROM {$wpdb->term_taxonomy} WHERE taxonomy = 'kbe_taxonomy'" );
 
-$wpdb->query( 'Delete From ' . $wpdb->prefix . "term_taxonomy Where taxonomy = 'kbe_tags'" );
+$wpdb->query( "DELETE FROM {$wpdb->term_taxonomy} WHERE taxonomy = 'kbe_tags'" );


### PR DESCRIPTION
Cleaning up the `uninstall.php` for large parts.

- One note is that I've omitted the code that deletes images. I'm not sure if that should be deleted as it is a very good possibility that the images are also used on other places.

- Also omitted the removal of child posts, as I don't think this is possible within the plugin.

I've actually not tested this as I'm not developing on a site where I'd be fine with deleting the data I've got. I'd love to get your help with this 😃 