### PR TITLE
Add docblocks for most of the functions

### DIFF
--- a/includes/admin/kbe-admin-functions.php
+++ b/includes/admin/kbe-admin-functions.php
@@ -1,8 +1,13 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-
-//=========> Enqueue color picker
+/**
+ * Enqueue scripts.
+ *
+ * Enqueue the required stylesheets and javascripts in the admin.
+ *
+ * @param string $hook_suffix Current page ID.
+ */
 function kbe_admin_scripts( $hook_suffix ) {
 	// Settings page
 	if ( $hook_suffix == 'kbe_knowledgebase_page_kbe_options' ) {
@@ -22,25 +27,42 @@ function kbe_admin_scripts( $hook_suffix ) {
 }
 add_action( 'admin_enqueue_scripts', 'kbe_admin_scripts' );
 
-//=========> Plugin menu
+/**
+ * Add submenus.
+ *
+ * Add submenus for the custom added pages.
+ *
+ * @since 1.0
+ */
 function kbe_plugin_menu() {
 	add_submenu_page( 'edit.php?post_type=kbe_knowledgebase', 'Order', 'Order', 'manage_options', 'kbe_order', 'wp_kbe_order' );
 	add_submenu_page( 'edit.php?post_type=kbe_knowledgebase', 'Settings', 'Settings', 'manage_options', 'kbe_options', 'wp_kbe_options' );
 }
 add_action( 'admin_menu', 'kbe_plugin_menu' );
 
-//  Require File kbe_order.php
+/**
+ * Output order page.
+ *
+ * Output the HTML for the 'order' page.
+ *
+ * @since 1.0
+ */
 function wp_kbe_order() {
 	require dirname( __FILE__ ) . '/../kbe-order.php';
 }
 
-//=========> Require Files
-//  kbe_settings.php
+/**
+ * Output settings page.
+ *
+ * Output the HTML for the settings page.
+ *
+ * @since 1.0
+ */
 function wp_kbe_options() {
 	require 'kbe-settings.php';
 }
 
-//=========> Register plugin settings
+
 function kbe_register_settings() {
 	register_setting( 'kbe_settings', 'kbe_settings', 'kbe_validate_settings' );
 }

--- a/includes/kbe-articles.php
+++ b/includes/kbe-articles.php
@@ -1,11 +1,13 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-/*
-============
-	Article Post type
-============
-*/
+/**
+ * Register 'article' post type.
+ *
+ * Register the main 'article' (actual slug is 'kbe_knowledgebase' post type that the plugin uses.
+ *
+ * @since 1.0
+ */
 function kbe_articles() {
 	$labels = array(
 		'name'               => 	__( 'Knowledgebase', 'wp-knowledgebase' ),
@@ -52,7 +54,13 @@ function kbe_articles() {
 }
 add_action( 'init', 'kbe_articles' );
 
-// Article taxonomy
+/**
+ * Register KB taxonomies.
+ *
+ * Register the 'category' taxonomy for the Articles post type.
+ *
+ * @since 1.0.0
+ */
 function kbe_taxonomies() {
 	// Add new taxonomy, make it hierarchical (like categories)
 	$labels = array(
@@ -81,6 +89,13 @@ function kbe_taxonomies() {
 }
 add_action( 'init', 'kbe_taxonomies', 0 );
 
+/**
+ * Register KB taxonomies.
+ *
+ * Register the 'tag' taxonomy for the Articles post type.
+ *
+ * @since 1.0.0
+ */
 function kbe_custom_tags() {
 	$labels = array(
 		'name'          =>  __( 'Knowledgebase Tags', 'wp-knowledgebase' ),
@@ -105,6 +120,15 @@ function kbe_custom_tags() {
 }
 add_action( 'init', 'kbe_custom_tags', 0 );
 
+/**
+ * Update article view count.
+ *
+ * Update/set the article view count by adding a count.
+ *
+ * @since 1.0
+ *
+ * @param int $postID Post ID to add the count to.
+ */
 function kbe_set_post_views( $postID ) {
 	$count_key = 'kbe_post_views_count';
 	$count     = get_post_meta( $postID, $count_key, true );
@@ -119,8 +143,19 @@ function kbe_set_post_views( $postID ) {
 }
 
 //To keep the count accurate, lets get rid of prefetching
+// @todo - what does this do?
 remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10 );
 
+/**
+ * Get article view count.
+ *
+ * Get the view count for a article post.
+ *
+ * @since 1.0
+ *
+ * @param int $postID Post ID to get the view count for.
+ * @return string View count with string text.
+ */
 function kbe_get_post_views( $postID ) {
 	$count_key = 'kbe_post_views_count';
 	$count     = get_post_meta( $postID, $count_key, true );
@@ -133,13 +168,31 @@ function kbe_get_post_views( $postID ) {
 	return $count . ' Views';
 }
 
-
+/**
+ * Article custom columns.
+ *
+ * Add custom columns to the Article post type.
+ *
+ * @since 1.0
+ *
+ * @param $existing_columns List of existing columns.
+ * @return array List of modified columns.
+ */
 function kbe_edit_columns( $existing_columns ) {
 	$columns = array( 'views' => __( 'Views', 'kbe' ) );
 	return array_merge( $existing_columns, $columns );
 }
 add_filter( 'manage_edit-kbe_knowledgebase_columns', 'kbe_edit_columns', 10 );
 
+/**
+ * Fill custom columns.
+ *
+ * Fill the newly added custom columns with the proper content.
+ *
+ * @since 1.0.
+ *
+ * @param string $column Column being processed/output.
+ */
 function kbe_custom_columns( $column ) {
 	global $post;
 	switch ( $column ) {
@@ -151,12 +204,31 @@ function kbe_custom_columns( $column ) {
 }
 add_action( 'manage_kbe_knowledgebase_posts_custom_column', 'kbe_custom_columns' );
 
+/**
+ * Make custom columns sortable.
+ *
+ * Make the custom added columns sortable.
+ *
+ * @since 1.2.0
+ *
+ * @param array $columns List of existing sortable columns.
+ * @return mixed List of modified sortable columns.
+ */
 function kbe_sortable_custom_columns( $columns ) {
 	$columns['views'] = 'views';
 	return $columns;
 }
 add_filter( 'manage_edit-kbe_knowledgebase_sortable_columns', 'kbe_sortable_custom_columns' );
 
+/**
+ * Actually sort columns.
+ *
+ * Actually modify the query that sorts the articles to sort them by the new order option.
+ *
+ * @since 1.2.0
+ *
+ * @param WP_Query $query Query that is being processed.
+ */
 function kbe_sort_custom_columns( $query ) {
 
 	if ( ! is_admin() || ! $query->is_main_query() ) {

--- a/includes/kbe-articles.php
+++ b/includes/kbe-articles.php
@@ -142,10 +142,6 @@ function kbe_set_post_views( $postID ) {
 	}
 }
 
-//To keep the count accurate, lets get rid of prefetching
-// @todo - what does this do?
-remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10 );
-
 /**
  * Get article view count.
  *

--- a/includes/kbe-articles.php
+++ b/includes/kbe-articles.php
@@ -171,7 +171,7 @@ function kbe_get_post_views( $postID ) {
  *
  * @since 1.0
  *
- * @param $existing_columns List of existing columns.
+ * @param array $existing_columns List of existing columns.
  * @return array List of modified columns.
  */
 function kbe_edit_columns( $existing_columns ) {

--- a/includes/kbe-core-functions.php
+++ b/includes/kbe-core-functions.php
@@ -129,11 +129,18 @@ function kbe_shortcode( $atts, $content = null ) {
 add_shortcode( 'kbe_knowledgebase', 'kbe_shortcode' );
 
 /**
- * @todo possibly remove this
+ * Get short content excerpt.
+ *
+ * Get a short content excerpt that is being used in the search results.
+ *
+ * @since 1.0
+ *
+ * @param  int    $limit Maximum content length (in characters).
+ * @return string        Short content to show in the search results.
  */
 function kbe_short_content( $limit ) {
 	$content = get_the_content();
-	$pad='&hellip;';
+	$pad = '&hellip;';
 
 	if ( strlen( $content ) <= $limit ) {
 		return strip_tags( $content );

--- a/includes/kbe-core-functions.php
+++ b/includes/kbe-core-functions.php
@@ -1,8 +1,13 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-
-//=========> Enqueue KBE Style file in header.php
+/**
+ * Enqueue scripts.
+ *
+ * Enqueue the required stylesheets and javascripts on the front end.
+ *
+ * @since 1.0
+ */
 function kbe_styles() {
 	if ( file_exists( get_stylesheet_directory() . '/wp_knowledgebase/kbe_style.css' ) ) {
 		$stylesheet = get_stylesheet_directory_uri() . '/wp_knowledgebase/kbe_style.css';
@@ -17,7 +22,13 @@ function kbe_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'kbe_styles' );
 
-//=========> Registering KBE widget area
+/**
+ * Register widget area.
+ *
+ * Register a widget area that is used on the KB pages.
+ *
+ * @since 1.0
+ */
 function kbe_register_sidebar() {
 	register_sidebar( array(
 		'name'          => __( 'WP Knowledgebase Sidebar', 'wp-knowledgebase' ),
@@ -31,6 +42,13 @@ function kbe_register_sidebar() {
 }
 add_action( 'widgets_init', 'kbe_register_sidebar' );
 
+/**
+ * Required search JS code.
+ *
+ * Javascript code required for the Search feature to work properly.
+ *
+ * @since 1.0
+ */
 function kbe_search_drop() {
 	if ( KBE_SEARCH_SETTING == 1 ) {
 		?><script type="text/javascript">
@@ -92,19 +110,27 @@ function kbe_search_drop() {
 }
 add_action( 'wp_footer', 'kbe_search_drop' );
 
-//=========>  KBE Knowledgebase Shortcode
+/**
+ * Knowledgebase shortcode.
+ *
+ * Register the [kbe_knowledgebase] shortcode.
+ *
+ * @since 1.0
+ *
+ * @param array $atts Attributes used with the shortcode (none available).
+ * @param null $content Content passed through the shortcode.
+ * @return mixed Knowledgebase page contents.
+ */
 function kbe_shortcode( $atts, $content = null ) {
 	$return_string = require dirname( __FILE__ ) . '/../template/kbe_knowledgebase.php';
 	wp_reset_query();
 	return $return_string;
 }
+add_shortcode( 'kbe_knowledgebase', 'kbe_shortcode' );
 
-function register_kbe_shortcodes() {
-	add_shortcode( 'kbe_knowledgebase', 'kbe_shortcode' );
-}
-add_action( 'init', 'register_kbe_shortcodes' );
-
-//=========>  KBE Short Content
+/**
+ * @todo possibly remove this
+ */
 function kbe_short_content( $limit ) {
 	$content = get_the_content();
 	$pad='&hellip;';
@@ -117,8 +143,15 @@ function kbe_short_content( $limit ) {
 	}
 }
 
-//=========> KBE Dynamic CSS
-function count_bg_color() {
+/**
+ * Dynamic CSS.
+ *
+ * Include the dynamic CSS that can be set on the settings page.
+ * This includes the color for the number of articles badge.
+ *
+ * @since 1.0
+ */
+function kbe_count_bg_color() {
 	if ( KBE_BG_COLOR ) {
 		$dynamic_css = '
 			#kbe_content h2 span.kbe_count,
@@ -134,7 +167,7 @@ function count_bg_color() {
 		wp_add_inline_style( 'kbe_theme_style', $dynamic_css );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'count_bg_color' );
+add_action( 'wp_enqueue_scripts', 'kbe_count_bg_color' );
 
 /**
  * Get page ID of KB.

--- a/includes/kbe-template-functions.php
+++ b/includes/kbe-template-functions.php
@@ -2,7 +2,13 @@
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 
-//=========> KBE Plugin Breadcrumbs
+/**
+ * Output breadcrumbs.
+ *
+ * Output the breadcrumbs. Used within the knowledgebase templates.
+ *
+ * @since 1.0
+ */
 function kbe_breadcrumbs() {
 	$parts = array(
 		array(
@@ -52,7 +58,13 @@ function kbe_breadcrumbs() {
 	?></ul><?php
 }
 
-//=========> KBE Search Form
+/**
+ * Output search form.
+ *
+ * Output the default search form, located at the top of KB pages by default.
+ *
+ * @since 1.0
+ */
 function kbe_search_form() {
 	// Life search
 	?><div id="live-search">
@@ -119,7 +131,14 @@ function kbe_template_chooser( $template ) {
 }
 add_filter( 'template_include', 'kbe_template_chooser' );
 
-//=========>  KBE Search Template
+/**
+ * Replace KB search template.
+ *
+ * @since 1.0
+ *
+ * @param $template
+ * @return string
+ */
 function template_chooser( $template ) {
 	global $wp_query;
 
@@ -130,14 +149,16 @@ function template_chooser( $template ) {
 			return get_stylesheet_directory() . '/wp_knowledgebase/kbe_search.php';
 		} else {
 			return plugin_dir_path( __FILE__ ) . '/../template/kbe_search.php';
-		}  //  redirect to kbe_search.php
+		}
 	}
 
 	return $template;
 }
 add_filter( 'template_include', 'template_chooser' );
 
-//=========> KBE Article Tags
+/**
+ * @todo possibly remove this
+ */
 function kbe_show_tags() {
 	$kbe_tags_term = get_the_terms( $post->ID, KBE_POST_TAGS );
 	if ( $kbe_tags_term ) {

--- a/includes/kbe-template-functions.php
+++ b/includes/kbe-template-functions.php
@@ -155,26 +155,3 @@ function template_chooser( $template ) {
 	return $template;
 }
 add_filter( 'template_include', 'template_chooser' );
-
-/**
- * @todo possibly remove this
- */
-function kbe_show_tags() {
-	$kbe_tags_term = get_the_terms( $post->ID, KBE_POST_TAGS );
-	if ( $kbe_tags_term ) {
-
-		?><div class="kbe_tags_div">
-            <div class="kbe_tags_icon"></div>
-            <ul><?php
-
-				foreach ( $kbe_tags_term as $kbe_tag ) {
-					?><li>
-                    <a href="<?php echo get_term_link( $kbe_tag->slug, KBE_POST_TAGS ); ?>"><?php echo $kbe_tag->name; ?></a>
-                    </li><?php
-				}
-
-			?></ul>
-        </div><?php
-
-	}
-}


### PR DESCRIPTION
A couple of questions:
- https://github.com/EnigmaWeb/wp-knowledgebase/compare/master...JeroenSormani:docs?expand=1#diff-b610e4686b0b7e395c8d6e414e9b1249R146

- I don't believe this does anything special... do you remember why it is there..?
https://github.com/EnigmaWeb/wp-knowledgebase/compare/master...JeroenSormani:docs?expand=1#diff-8e80060d05413449f350cfa143626120R132

- This is not used anywhere, I believe I saw some other version of the plugin that we discussed earlier that also had this deprecated. Are you cool with completely removing it now?
https://github.com/EnigmaWeb/wp-knowledgebase/compare/master...JeroenSormani:docs?expand=1#diff-3c2efc0211f13833d0abf46761d6ee20R160