### PR TITLE
No need to do anything with the shortcode in admin

### DIFF
--- a/includes/kbe-core-functions.php
+++ b/includes/kbe-core-functions.php
@@ -122,9 +122,11 @@ add_action( 'wp_footer', 'kbe_search_drop' );
  * @return mixed Knowledgebase page contents.
  */
 function kbe_shortcode( $atts, $content = null ) {
-	$return_string = require dirname( __FILE__ ) . '/../template/kbe_knowledgebase.php';
-	wp_reset_query();
-	return $return_string;
+	if ( !is_admin() ) {
+		$return_string = require dirname( __FILE__ ) . '/../template/kbe_knowledgebase.php';
+		wp_reset_query();
+		return $return_string;
+	}
 }
 add_shortcode( 'kbe_knowledgebase', 'kbe_shortcode' );
 


### PR DESCRIPTION
I'm working on compatibility with Divi and it really looks bad when the shortcode is executed in the admin area.