### PR TITLE
Shortcodes should return a value not output/echo

### DIFF
--- a/includes/kbe-core-functions.php
+++ b/includes/kbe-core-functions.php
@@ -123,8 +123,14 @@ add_action( 'wp_footer', 'kbe_search_drop' );
  */
 function kbe_shortcode( $atts, $content = null ) {
 	if ( !is_admin() ) {
-		$return_string = require dirname( __FILE__ ) . '/../template/kbe_knowledgebase.php';
+		ob_start();
+		
+		require dirname( __FILE__ ) . '/../template/kbe_knowledgebase.php';
 		wp_reset_query();
+		
+		$return_string = ob_get_contents();
+		ob_end_clean();
+
 		return $return_string;
 	}
 }


### PR DESCRIPTION
`require()` will print the output of the included file's content by default even if returning as a value. Previous implementation results in broken result json response for any pages of the site that used the `[kbe_knowledgebase]` shortcode within their content when referenced using the REST API.